### PR TITLE
Update nginx config to add /health ‘health check’.

### DIFF
--- a/Ingress/controllers/nginx-alpha/controller.go
+++ b/Ingress/controllers/nginx-alpha/controller.go
@@ -43,9 +43,14 @@ http {
   server_names_hash_bucket_size 255;
 
   server {
-      listen 80 default_server;
-      server_name _;
-      return 404;
+    listen 80 default_server;
+    server_name _;
+    return 404;
+
+    location /health {
+      access_log off;
+      return 200;
+    }
   }
 
 {{range $ing := .Items}}


### PR DESCRIPTION
Doesn’t actually check anything other than whether Nginx is running and has bound the port.